### PR TITLE
Stop scheduling and setup manual trigger

### DIFF
--- a/.github/workflows/build_faiss.yml
+++ b/.github/workflows/build_faiss.yml
@@ -2,11 +2,15 @@ name: Build Faiss
 
 on:
   ### Just stop running actions by push
-  # push:
+  #push:
 
-  schedule:
-    # Every Monday, UTC 0:00 (JST 9:00)
-    - cron: 0 0 * * 1
+  ### Manual trigger
+  workflow_dispatch:
+
+  ### Trigger every week
+  # schedule:
+  #   # Every Monday, UTC 0:00 (JST 9:00)
+  #   - cron: 0 0 * * 1
 
 jobs:
   build-faiss:


### PR DESCRIPTION
I stop scheduling because building consumes a lot of action resources....